### PR TITLE
usage of "${@}" to run multiple commands in CMD

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ echo '> Fully Booted.'
 
 if [[ -n "${@}" ]]; then
 	echo "> Executing \`${@}\`"
-	$@ &
+	"${@}" &
 else
 	sleep infinity &
 fi


### PR DESCRIPTION
This allows entrypoint.sh to execute multiple commands using this syntax: 

```Dockerfile
CMD docker-cron link && docker-cron run
```