### PR TITLE
fix: in bash4.4, calling "" directly does not work

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ echo '> Fully Booted.'
 
 if [[ -n "${@}" ]]; then
 	echo "> Executing \`${@}\`"
-	"${@}" &
+	/bin/bash -c "${@}" &
 else
 	sleep infinity &
 fi


### PR DESCRIPTION
Bash version 4.4 (found in debian stretch and later) does not process correctly  `"${@}" &` as it tries to evaluate the string as one command instead of a string containing multiple command.

The below code is broken with bash4.4 but not in bash4.3.
```
entrypoint.sh "ls -l && ls -la"
```