### PR TITLE
DOPS-5351: ignore bash processes from sig term loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ kill_remaining_process() {
 	if [ -n "$PIDS" ]; then
 		kill -TERM $PIDS
 		for PID in $PIDS; do
-			processName= $(cat /proc/"$PID"/cmdline)
+			processName=$(cat /proc/$PID/cmdline)
 			echo "> Waiting for process $PID ($processName) to finish.." 
 			if [[ "$processName" == "bash" ]]; then
 				echo "> Skipping bash shell process.."


### PR DESCRIPTION
This pull request includes an important update to the `entrypoint.sh` script to improve the handling of remaining processes. The key change is to ignore bash shell processes during the termination phase.

Changes to process handling:

* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R17-R33): Enhanced the `kill_remaining_process()` function to ignore bash shell processes when sending SIGTERM and waiting for processes to finish. This ensures that entrypoint process is not stuck in infinite loop