### PR TITLE
DOPS-5351: fix bash process ignore condition

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ kill_remaining_process() {
 		for PID in $PIDS; do
 			processName=$(cat /proc/$PID/cmdline)
 			echo "> Waiting for process $PID ($processName) to finish.." 
-			if [[ "$processName" == "bash" ]]; then
+			if [[ "$processName" == *"bash"* ]]; then
 				echo "> Skipping bash shell process.."
 				continue
 			fi 


### PR DESCRIPTION
This pull request includes a small change to the `entrypoint.sh` script. The change modifies the condition in the `kill_remaining_process()` function to correctly identify and skip any process that contains "bash" in its name.

* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L29-R29): Updated the condition to use a wildcard match for "bash" in the `kill_remaining_process()` function.